### PR TITLE
Redact sensitive data from Strava logging

### DIFF
--- a/apps/strava-webhook/lambda/__tests__/strava.test.ts
+++ b/apps/strava-webhook/lambda/__tests__/strava.test.ts
@@ -49,7 +49,12 @@ describe('Strava API Utilities', () => {
     it('should filter activity objects to only safe fields', () => {
       const activity = {
         id: 12345,
-        athlete: { id: 123 },
+        athlete: {
+          id: 123,
+          username: 'johndoe',
+          firstname: 'John',
+          lastname: 'Doe',
+        },
         name: 'Morning Run',
         type: 'Run',
         sport_type: 'Run',
@@ -77,6 +82,12 @@ describe('Strava API Utilities', () => {
       expect(result.moving_time).toBe(3600);
       expect(result.elapsed_time).toBe(3700);
 
+      // Athlete should only have ID, no PII (names, username)
+      expect(result.athlete).toEqual({ id: 123 });
+      expect(result.athlete.firstname).toBeUndefined();
+      expect(result.athlete.lastname).toBeUndefined();
+      expect(result.athlete.username).toBeUndefined();
+
       // Should NOT have these fields
       expect(result.description).toBeUndefined();
       expect(result.start_latlng).toBeUndefined();
@@ -92,15 +103,20 @@ describe('Strava API Utilities', () => {
         athlete: {
           id: 123,
           access_token: 'secret',
-          name: 'John Doe',
+          firstname: 'John',
+          lastname: 'Doe',
         },
         description: 'a'.repeat(100),
       };
 
       const result = sanitizeForLogging(data);
 
-      expect(result.athlete.access_token).toBe('[REDACTED]');
-      expect(result.athlete.id).toBe(123);
+      // Athlete should be sanitized to only ID (no PII, no tokens)
+      expect(result.athlete).toEqual({ id: 123 });
+      expect(result.athlete.firstname).toBeUndefined();
+      expect(result.athlete.lastname).toBeUndefined();
+      expect(result.athlete.access_token).toBeUndefined();
+
       expect(result.description).toBe('a'.repeat(50) + '...');
     });
 

--- a/apps/strava-webhook/lambda/strava.ts
+++ b/apps/strava-webhook/lambda/strava.ts
@@ -25,13 +25,19 @@ export function sanitizeForLogging(data: any): any {
   if (data && typeof data === 'object') {
     const sanitized: any = {};
 
-    // List of fields to keep from activity objects
-    const allowedFields = ['id', 'athlete', 'name', 'type', 'sport_type', 'start_date', 'moving_time', 'elapsed_time'];
+    // List of fields to keep from activity objects (excluding athlete - handled separately)
+    const allowedFields = ['id', 'name', 'type', 'sport_type', 'start_date', 'moving_time', 'elapsed_time'];
 
     for (const [key, value] of Object.entries(data)) {
       // Skip sensitive fields
       if (key === 'access_token' || key === 'refresh_token') {
         sanitized[key] = '[REDACTED]';
+        continue;
+      }
+
+      // Special handling for athlete field - only keep ID to avoid leaking PII (names)
+      if (key === 'athlete' && value && typeof value === 'object' && 'id' in value) {
+        sanitized[key] = { id: value.id };
         continue;
       }
 


### PR DESCRIPTION
## Summary

Fixes #2

Removes sensitive data from CloudWatch logs to reduce security blast radius and comply with security best practices.

## Changes Made

### Security Improvements
- ✅ **Removed access token logging** - Was logging first 20 characters of tokens
- ✅ **Removed full activity payloads** - Contained sensitive user data (location, heart rate, device info)
- ✅ **Sanitized update logging** - Shows field names only, not values
- ✅ **Added sanitization helper** - Reusable function for safe logging

### Implementation Details

**New `sanitizeForLogging()` helper** (lambda/strava.ts:15-51)
- Truncates long strings to 50 characters
- Redacts `access_token` and `refresh_token` fields
- Filters activity objects to safe fields only (id, type, athlete_id, start_date, etc.)
- Recursively sanitizes nested objects and arrays

**Removed/Updated Logging:**
- Line 111: ❌ Removed `console.log(\`Using access token: ${accessToken.substring(0, 20)}...\`)`
- Line 114: ❌ Removed `console.log(\`Request body: ${requestBody.substring(0, 200)}...\`)`
- Line 134: ❌ Removed `console.log(\`Strava API response data:\`, JSON.stringify(responseData, null, 2))`
- Line 148: ✏️ Changed to log field names only: `console.log(\`Updating activity ${activityId} - fields: ${fieldsUpdated}\`)`

## Testing

Added comprehensive test suite for sanitization (9 new tests):
- ✅ String truncation (50 char limit)
- ✅ Token redaction (access_token, refresh_token)
- ✅ Activity payload filtering (safe fields only)
- ✅ Recursive sanitization
- ✅ Array handling
- ✅ Primitive value handling

**Full test suite: 36 tests passing** (9 OAuth + 18 webhook + 9 strava)

## Security Benefits

### Before:
```
Using access token: 1234567890abcdefghij...
Request body: {"description":"Great powder day! Started at 45.4,-121.7...
Strava API response data: {
  "id": 123456,
  "athlete": {...},
  "description": "Full user content...",
  "start_latlng": [45.4, -121.7],
  "device_name": "Garmin Fenix 7",
  "heartrate_average": 165,
  ...
}
```

### After:
```
Updating activity 123456 for athlete 987654 with description (245 chars)
Strava API response status: 200 OK
Updated activity 123456 (type: BackcountrySki)
```

## Acceptance Criteria

- ✅ No access tokens (full or partial) in CloudWatch logs
- ✅ No full activity payloads logged
- ✅ Activity IDs, status codes, and minimal metadata still available for debugging
- ✅ Tests validate sanitization behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)