### PR TITLE
Fix license in README to match LICENSE file

### DIFF
--- a/apps/strava-webhook/README.md
+++ b/apps/strava-webhook/README.md
@@ -382,4 +382,4 @@ This prevents:
 
 ## License
 
-MIT
+CC0 1.0 Universal (Public Domain)


### PR DESCRIPTION
## Summary

Fixes #11

Simple one-line fix to correct the license statement in the README.

## Changes

Updated `apps/strava-webhook/README.md`:
- **Before:** `MIT`
- **After:** `CC0 1.0 Universal (Public Domain)`

This now matches the actual `LICENSE` file at the root of the repository, which is CC0 1.0 Universal.

## Verification

- [x] LICENSE file is CC0 1.0 Universal
- [x] README now matches LICENSE file