### PR TITLE
Fix Idempotency Issue (GH-22)

### DIFF
--- a/apps/strava-webhook/lambda/__tests__/processor.test.ts
+++ b/apps/strava-webhook/lambda/__tests__/processor.test.ts
@@ -190,6 +190,23 @@ describe('Webhook Handler', () => {
       expect(strava.updateActivity).not.toHaveBeenCalled();
     });
 
+    it('should not duplicate forecast if text pattern matches but URL is different/missing', async () => {
+      const event = createSQSEvent(mockWebhookEvent);
+
+      // Mock activity with existing forecast but URL is shortened/different
+      const activityWithShortenedUrl = {
+        ...mockBackcountryActivity,
+        description: 'Great day!\n\nNWAC Mt Hood Zone forecast: 3🟧/3🟧/2🟨 (https://strava.app.link/xyz)',
+      };
+      vi.mocked(strava.getActivity).mockResolvedValue(activityWithShortenedUrl);
+
+      await handler(event, {} as any, {} as any);
+
+      // Currently this fails (it WILL call updateActivity because URL check fails)
+      // We want it to NOT call updateActivity
+      expect(strava.updateActivity).not.toHaveBeenCalled();
+    });
+
     it('should add forecast even if description mentions NWAC naturally', async () => {
       const event = createSQSEvent(mockWebhookEvent);
 

--- a/apps/strava-webhook/lambda/processor.ts
+++ b/apps/strava-webhook/lambda/processor.ts
@@ -117,10 +117,12 @@ async function processActivity(
   }
 
   // Check if description already has forecast (idempotency)
-  // Look for our specific forecast URL pattern: nwac.us/avalanche-forecast/#/forecast/
-  // Skip if forecast exists, UNLESS user manually invoked with #avy_forecast (allows retry)
+  // Look for our specific forecast text pattern or the URL
+  // Pattern: "NWAC [Zone Name] Zone forecast:"
   const currentDescription = activity.description || '';
-  const hasForecast = currentDescription.includes('nwac.us/avalanche-forecast/#/forecast/');
+  const hasForecast =
+    currentDescription.includes('nwac.us/avalanche-forecast/#/forecast/') ||
+    /NWAC .* Zone forecast:/.test(currentDescription);
 
   if (hasForecast && !hasCommand) {
     console.log('Activity description already contains forecast, skipping update');


### PR DESCRIPTION
Improves the idempotency check in the processor Lambda to detect existing forecasts by text pattern in addition to the specific URL. This handles cases where the URL might be shortened or modified.

## Changes
- Updated `processor.ts` to check for `NWAC .* Zone forecast:` regex.
- Renamed `webhook.test.ts` to `processor.test.ts`.
- Added reproduction test case.

Closes #22