### PR TITLE
Upgrade Lambda Runtime to Node 22

### DIFF
--- a/apps/strava-webhook/lib/strava-webhook-stack.ts
+++ b/apps/strava-webhook/lib/strava-webhook-stack.ts
@@ -71,7 +71,7 @@ export class StravaWebhookStack extends cdk.Stack {
     // Lambda Function: Ingest Handler (API Gateway -> SQS)
     // ============================================
     const ingestFunction = new lambda.Function(this, 'IngestHandler', {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'ingest.handler',
       code: lambda.Code.fromAsset('dist/lambda'),
       timeout: cdk.Duration.seconds(3), // Fast response required
@@ -88,7 +88,7 @@ export class StravaWebhookStack extends cdk.Stack {
     // Lambda Function: Processor Handler (SQS -> Logic)
     // ============================================
     const processorFunction = new lambda.Function(this, 'ProcessorHandler', {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'processor.handler',
       code: lambda.Code.fromAsset('dist/lambda'),
       timeout: cdk.Duration.seconds(30),
@@ -110,7 +110,7 @@ export class StravaWebhookStack extends cdk.Stack {
     // Lambda Function: OAuth Flow
     // ============================================
     const oauthFunction = new lambda.Function(this, 'OAuthHandler', {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'oauth.handler',
       code: lambda.Code.fromAsset('dist/lambda'),
       timeout: cdk.Duration.seconds(10),
@@ -128,7 +128,7 @@ export class StravaWebhookStack extends cdk.Stack {
     // Lambda Function: Web UI
     // ============================================
     const webFunction = new lambda.Function(this, 'WebHandler', {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'web.handler',
       code: lambda.Code.fromAsset('dist/lambda'),
       timeout: cdk.Duration.seconds(5),

--- a/apps/strava-webhook/package.json
+++ b/apps/strava-webhook/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && npm run bundle && npm run copy-zones",
-    "bundle": "esbuild lambda/ingest.ts lambda/processor.ts lambda/oauth.ts lambda/web.ts --bundle --platform=node --target=node20 --outdir=dist/lambda --external:@aws-sdk/* --format=cjs",
+    "bundle": "esbuild lambda/ingest.ts lambda/processor.ts lambda/oauth.ts lambda/web.ts --bundle --platform=node --target=node22 --outdir=dist/lambda --external:@aws-sdk/* --format=cjs",
     "copy-zones": "mkdir -p dist/lambda/data/zones && cp ../../packages/forecast-api/data/zones/*.geojson dist/lambda/data/zones/",
     "watch": "tsc -w",
     "test": "vitest",


### PR DESCRIPTION
Upgrades the Lambda runtime from Node.js 20.x to Node.js 22.x.

## Changes
- Updated CDK stack to use `NODEJS_22_X`.
- Updated `package.json` bundle target to `node22`.

## Verification
- Verified `cdk synth` output contains `Runtime: nodejs22.x`.
- Verified build succeeds.

Closes #21